### PR TITLE
Define max-http-header-size

### DIFF
--- a/jre8-alpine/parkingpage/src/main/resources/application.properties
+++ b/jre8-alpine/parkingpage/src/main/resources/application.properties
@@ -4,3 +4,6 @@
 # Use this when packaging for App Service
 logging.file = /home/LogFiles/Application/spring.${WEBSITE_INSTANCE_ID}.log
 server.port = 80
+
+# Increase the default size so that Easy Auth headers don't exceed the size limit
+server.max-http-header-size=16384


### PR DESCRIPTION
- Easy Auth headers can result in incoming requests exceeding the default header size limit. This commit increases the limit to an arbitrarily large value.