### PR TITLE
Move Spring Boot configuration from application.properties to init_container.sh

### DIFF
--- a/parkingpage/src/main/resources/application.properties
+++ b/parkingpage/src/main/resources/application.properties
@@ -1,9 +1,1 @@
-# Use this for debugging locally
-# logging.file = /home/LogFiles/Application/spring.dev.log
-
-# Use this when packaging for App Service
-logging.file = /home/LogFiles/Application/spring.${WEBSITE_INSTANCE_ID}.log
-server.port = 80
-
-# Increase the default size so that Easy Auth headers don't exceed the size limit
-server.max-http-header-size=16384
+# Application specific properties

--- a/shared/init_container.sh
+++ b/shared/init_container.sh
@@ -105,12 +105,23 @@ then
     mkdir -p /home/site/wwwroot
 fi
 
+# BEGIN: Configure Spring Boot properties
+# Precedence order of properties can be found here: https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html
+
+SPRING_BOOT_PROPS=
+SPRING_BOOT_PROPS=$SPRING_BOOT_PROPS --server.port=80
+SPRING_BOOT_PROPS=$SPRING_BOOT_PROPS --logging.file=/home/LogFiles/Application/spring.$WEBSITE_INSTANCE_ID.log
+# Increase the default size so that Easy Auth headers don't exceed the size limit
+SPRING_BOOT_PROPS=$SPRING_BOOT_PROPS --server.max-http-header-size=16384
+
+# END: Configure Spring Boot properties
+
 # check if app.jar is present and launch it. Otherwise, launch default.jar
 if [ ! -f /home/site/wwwroot/app.jar ]
 then
     echo Launching default.jar    
     cp /tmp/webapps/default.jar /home/site/wwwroot/default.jar
-    java -jar /home/site/wwwroot/default.jar
+    java -jar /home/site/wwwroot/default.jar $SPRING_BOOT_PARAMS
 else
     # If the WEBSITE_LOCAL_CACHE_OPTION application setting is set to Always, copy the jar from the 
     # remote storage to a local folder
@@ -123,6 +134,6 @@ else
         JAR_PATH=/home/site/wwwroot/app.jar
     fi
     echo Launching "$JAR_PATH" using JAVA_OPTS="$JAVA_OPTS"
-    java $JAVA_OPTS -jar "$JAR_PATH"
+    java $JAVA_OPTS -jar "$JAR_PATH" $SPRING_BOOT_PARAMS
 fi
 


### PR DESCRIPTION
- This change takes care of configuring App Service specific properties in init_container.sh so that apps don't have to configure them to be able to run on App Service