### PR TITLE
Update base images

### DIFF
--- a/java11-alpine/Dockerfile
+++ b/java11-alpine/Dockerfile
@@ -1,8 +1,8 @@
 ########################################################
 ### ***DO NOT EDIT*** This is an auto-generated file ###
 ########################################################
-ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine
-FROM mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine
+ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine-with-tools
+FROM mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine-with-tools
 LABEL maintainer="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV PORT 80

--- a/jre8-alpine/Dockerfile
+++ b/jre8-alpine/Dockerfile
@@ -1,8 +1,8 @@
 ########################################################
 ### ***DO NOT EDIT*** This is an auto-generated file ###
 ########################################################
-ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine
-FROM mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine
+ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:8u212-zulu-alpine-with-tools
+FROM mcr.microsoft.com/java/jre-headless:8u212-zulu-alpine-with-tools
 LABEL maintainer="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV PORT 80

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -22,14 +22,14 @@ function setup
         'jre8-alpine'
         {
             $content = (Get-Content -path $dockerFileTemplatePath -Raw) `
-                -replace '__PLACEHOLDER_BASEIMAGE__','mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine'
+                -replace '__PLACEHOLDER_BASEIMAGE__','mcr.microsoft.com/java/jre-headless:8u212-zulu-alpine-with-tools'
             break
         }
 
         'java11-alpine'
         {
             $content = (Get-Content -path $dockerFileTemplatePath -Raw) `
-                -replace '__PLACEHOLDER_BASEIMAGE__','mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine'
+                -replace '__PLACEHOLDER_BASEIMAGE__','mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine-with-tools'
             break
         }
     }


### PR DESCRIPTION
- Use the base images that contain the jStack, jMap tools
- The Java8 base image also contains jCmd. At the time of this commit the Java11 base image does not contain jCmd.