### PR TITLE
Do not create empty wwwroot directory

### DIFF
--- a/shared/init_container.sh
+++ b/shared/init_container.sh
@@ -130,11 +130,6 @@ fi
 
 # END: Process startup file / startup command, if any
 
-if [ ! -d /home/site/wwwroot ]
-then
-    mkdir -p /home/site/wwwroot
-fi
-
 # check if app.jar is present and launch it. Otherwise, launch the parking page app.
 if [ ! -f /home/site/wwwroot/app.jar ]
 then


### PR DESCRIPTION
- The wwwroot directory was being created earlier for the parking page jar.
- However, now we don't need it as the parking page jar is not copied to wwwroot but is instead run from /tmp/appservice directory.